### PR TITLE
feat(nix-index): improve error message when `nix-env` is killed by signal

### DIFF
--- a/src/nixpkgs.rs
+++ b/src/nixpkgs.rs
@@ -105,10 +105,10 @@ impl PackagesQuery<ChildStdout> {
             if !result.status.success() {
                 let message = String::from_utf8_lossy(&result.stderr);
 
-                return Err(Error::Command(match result.status.code() {
-                    Some(c) => format!("nix-env failed with exit code {}:\n{}", c, message),
-                    None => format!("nix-env failed with unknown exit code:\n{}", message),
-                }));
+                return Err(Error::Command(format!(
+                    "nix-env failed with {}:\n{}",
+                    result.status, message,
+                )));
             }
 
             Ok(())


### PR DESCRIPTION
before

```
caused by: nix-env failed with error: nix-env failed with unknown exit code:
```

after

```
caused by: nix-env failed with error: nix-env failed with signal: 9 (SIGKILL):
```

this will make issues like #157 more diagnosable