### PR TITLE
Make `--top-level` the default behavior of `nix-locate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Fixed
 ### Changed
 
+* `--top-level` is now the default. To use the old default, add `--all`.
+
 ## 0.1.8
 ### Added
 

--- a/command-not-found.sh
+++ b/command-not-found.sh
@@ -16,7 +16,7 @@ command_not_found_handle () {
 
     toplevel=nixpkgs # nixpkgs should always be available even in NixOS
     cmd=$1
-    attrs=$(@out@/bin/nix-locate --minimal --no-group --type x --type s --top-level --whole-name --at-root "/bin/$cmd")
+    attrs=$(@out@/bin/nix-locate --minimal --no-group --type x --type s --whole-name --at-root "/bin/$cmd")
     len=$(echo -n "$attrs" | grep -c "^")
 
     case $len in

--- a/src/bin/nix-locate.rs
+++ b/src/bin/nix-locate.rs
@@ -187,7 +187,7 @@ fn process_args(matches: Opts) -> result::Result<Args, clap::Error> {
         file_type: matches
             .r#type
             .unwrap_or_else(|| files::ALL_FILE_TYPES.to_vec()),
-        only_toplevel: matches.top_level,
+        only_toplevel: !matches.all,
         color,
         minimal: matches.minimal,
     };
@@ -255,9 +255,9 @@ struct Opts {
     #[clap(long, name = "HASH")]
     hash: Option<String>,
 
-    /// Only print matches from packages that show up in `nix-env -qa`.
+    /// Print all matches, not only print from packages that show up in `nix-env -qa`.
     #[clap(long)]
-    top_level: bool,
+    all: bool,
 
     /// Only print matches for files that have this type. If the option is given multiple times,
     /// a file will be printed if it has any of the given types.


### PR DESCRIPTION
It happens pretty often to me that I'm trying to find out which packages contain a certain header file (e.g. `unistd.h`). In those cases I usually don't care at all about which e.g. FHS env has this header as well.

I can't remember a single time where this was actually helpful, so I'm questioning whether this is a sensible default. I'll use this patch in my own setup for now, but I thought I could suggest it here as well.

cc @RaitoBezarius @figsoda @bennofs 