### PR TITLE
README: update link to hm module

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Or run it once with:
   nix-shell -p blender.out --run ...
 ```
 
-A [`home-manager` module](https://nix-community.github.io/home-manager/options.html#opt-programs.nix-index.enable) is now available to integrate `nix-index` with `bash`, `zsh`, and `fish` using this script.
+A [`home-manager` module](https://nix-community.github.io/home-manager/options.xhtml#opt-programs.nix-index.enable) is now available to integrate `nix-index` with `bash`, `zsh`, and `fish` using this script.
 
 ## Contributing
 If you find any missing features that you would like to implement, I'm very happy about any PRs! You can also create an issue first if the feature is more complex so we can discuss possible implementations.


### PR DESCRIPTION
The old one points to 404 GitHub page.