### PR TITLE
Exclude packages with no files from the index.

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -71,10 +71,16 @@ impl Writer {
         files: FileTree,
         filter_prefix: &[u8],
     ) -> io::Result<()> {
+        let entries = files.to_list(filter_prefix);
+
+        // Don't add packages with no file entries to the database.
+        if entries.is_empty() {
+            return Ok(());
+        }
         let writer = self.writer.as_mut().expect("not dropped yet");
         let mut encoder =
             frcode::Encoder::new(writer, b"p".to_vec(), serde_json::to_vec(&path).unwrap());
-        for entry in files.to_list(filter_prefix) {
+        for entry in entries {
             entry.encode(&mut encoder)?;
         }
         Ok(())


### PR DESCRIPTION
Noticed that nix-index-database "small" mostly consists of package(^p\0) lines without its corresponding path as many nix packages don't have entries under /bin/.

This reduced the small index size from 3.9MB to 967K. Whereas the number of paths in the database is identical and equall to 82984(nix-index ran at `github:NixOS/nixpkgs/5aba99242eb2ca90cdc4eea40d61ad9157e5913c`)