### PR TITLE
fix(`command-not-found.nu`): don't use `--top-level`

### DIFF
--- a/command-not-found.nu
+++ b/command-not-found.nu
@@ -29,7 +29,7 @@
     ]
     $lines | str join "\n"
   }
-  let pkgs = (@out@/bin/nix-locate --minimal --no-group --type x --type s --top-level --whole-name --at-root $"/bin/($cmd_name)" | lines)
+  let pkgs = (@out@/bin/nix-locate --minimal --no-group --type x --type s --whole-name --at-root $"/bin/($cmd_name)" | lines)
   let len = ($pkgs | length)
   let ret = match $len {
     0 => null,


### PR DESCRIPTION
Fixes https://github.com/nix-community/nix-index/issues/275

`--top-level` became the default behavior and was removed in https://github.com/nix-community/nix-index/commit/66cd6792464368d9756d0283099bb6918ce8e30a.