### PR TITLE
Skip package sets that may not exist in older nixpkgs revisions.

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,9 +4,9 @@ use crate::package::StorePath;
 
 error_chain::error_chain! {
     errors {
-        QueryPackages {
+        QueryPackages(set: Option<String>) {
             description("query packages error")
-            display("querying available packages failed")
+            display("querying available packages in set '{}' failed", set.as_ref().unwrap_or(&".".to_string()))
         }
         FetchFiles(path: StorePath) {
             description("file listing fetch error")


### PR DESCRIPTION
When running nix-index on old nixpkgs, scopes like rPackages are missing, so instead of exiting with an error, this change issues an error to stderr and skips such package set.

Motivation: while it's possible to use an older version of nix-index to create the index for older nixpkgs, newer nix-index is much more performant so it's useful to be able to use it.